### PR TITLE
localStorage namespacing, parsing new vocab fixed, new configs

### DIFF
--- a/JPDB Immersion Kit Examples.js
+++ b/JPDB Immersion Kit Examples.js
@@ -618,7 +618,7 @@
         const anchor = createAnchor('0.5rem');
         const starIcon = document.createElement('span');
         const storedValue = getItem(state.vocab);
-        console.log(storedValue);
+        // console.log(storedValue);
 
         // Determine the star icon (filled or empty) based on stored value
         if (storedValue) {

--- a/JPDB Immersion Kit Examples.js
+++ b/JPDB Immersion Kit Examples.js
@@ -1572,7 +1572,7 @@
                 'This will reset all your settings to default. Are you sure?',
                 () => {
                     Object.keys(localStorage).forEach(key => {
-                        if (key.startsWith(scriptPrefix + configPrefix)) { // Jai - edited as config variables are also script-prefixed now
+                        if (key.startsWith(scriptPrefix + configPrefix)) {
                             localStorage.removeItem(key);
                         }
                     });


### PR DESCRIPTION
Changes made by me:
- Added 2 new config options:
  - Definitions on right in wide mode (instead of the usual left)
  - Default to exact search - controls whether the examples browser initially shows exact or non-exact search results
- Added a script-wide prefix to the localStorage variables used in the script, to avoid potential clashing with other programs and make it easier to find variables belonging to this script
> - Favourites are still exported and imported without the script prefix for conciseness and full backwards compatibility
> - Non-prefixed variables will no longer be written, but they will still be read if no prefixed one is found (for backwards compatibility - in this case a prefixed version will also be created immediately) and removed (along with the prefixed version) on removing favourites.

Changes made by original repo owner:
Fixed new vocab parsing (issue where results would never load)